### PR TITLE
Update to bindgen 0.30.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo install xargo --vers 0.3.8
 
 # Use Bindgen as a binary to generate headers
-RUN cargo install bindgen --vers 0.25.3
+RUN cargo install bindgen --vers 0.30.0
 
 # Add the rust-src component so we can build `core`
 RUN rustup component add rust-src

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ arm-none-eabi-gcc   | 6.1                   | [Current Version](https://develope
 Rust (nightly)      | nightly-2017-06-12    | [rustup.rs](https://www.rustup.rs/)
 Rust source         | nightly-2017-06-12    | `rustup component add rust-src`
 Xargo               | 0.3.8                 | `cargo install xargo`
-Bindgen             | 0.25.3                | `cargo install bindgen`
+Bindgen             | 0.30.0                | `cargo install bindgen`
 
 If you would like more detailed installation instructions, please look at [The Detailed Setup Instructions](./SETUP.md).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -77,7 +77,7 @@ Xargo makes compiling embedded crates easier. Bindgen automatically generates Ru
 
 ```bash
 cargo install xargo --vers 0.3.8
-cargo install bindgen --vers 0.25.3
+cargo install bindgen --vers 0.30.0
 ```
 
 ## 6. Install Rust Core Source

--- a/build.rs
+++ b/build.rs
@@ -91,7 +91,6 @@ fn generate_ble(outdir: &String) {
     cmd.arg("--no-doc-comments");
     cmd.arg("--use-core");
     cmd.arg("--ctypes-prefix=ctypes");
-    cmd.arg("--no-unstable-rust");
     cmd.arg("--with-derive-default");
 
     cmd.arg("--output");


### PR DESCRIPTION
The --no-unstable-rust flag was removed was removed in bindgen 0.26.x and
replaced with an --unstable-rust flag. Now we do not need to provide any flag
to avoid generating unstable rust.