### PR TITLE
Update bindgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ target
 *.a
 *.bk
 *.gdbinit
+.vscode
+
+# Libraries should not check in Cargo.lock
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52dk-sys"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["James Munns <james.munns@gmail.com>"]
 build = "build.rs"
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,14 @@ ENV PATH="/gcc-arm-none-eabi-6-2017-q1-update/bin:${PATH}"
 
 # Install rust
 RUN curl https://sh.rustup.rs -sSf > install_rust.sh
-RUN /bin/bash /install_rust.sh -y --default-toolchain nightly-2017-06-12
+RUN /bin/bash /install_rust.sh -y --default-toolchain nightly-2017-11-15
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Use Xargo for cross platform building
 RUN cargo install xargo --vers 0.3.8
 
 # Use Bindgen as a binary to generate headers
-RUN cargo install bindgen --vers 0.30.0
+RUN cargo install bindgen --vers 0.31.3
 
 # Add the rust-src component so we can build `core`
 RUN rustup component add rust-src
@@ -48,4 +48,4 @@ RUN git clone --recursive https://github.com/jamesmunns/nrf52dk-sys
 # Move to the git repo
 WORKDIR /nrf52dk-sys
 
-CMD ["xargo", "build", "--example", "ble_app_template"]
+CMD ["xargo", "build", "--example", "ble_app_template", "--quiet"]

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Tool                | Recommended Version   | Link/Install
 :---                | :------------------   | :---
 Clang               | 3.9                   | [debian/ubuntu](http://apt.llvm.org/) or [source](http://releases.llvm.org/download.html)
 arm-none-eabi-gcc   | 6.1                   | [Current Version](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads)
-Rust (nightly)      | nightly-2017-06-12    | [rustup.rs](https://www.rustup.rs/)
-Rust source         | nightly-2017-06-12    | `rustup component add rust-src`
+Rust (nightly)      | nightly-2017-11-15    | [rustup.rs](https://www.rustup.rs/)
+Rust source         | nightly-2017-11-15    | `rustup component add rust-src`
 Xargo               | 0.3.8                 | `cargo install xargo`
 Bindgen             | 0.30.0                | `cargo install bindgen`
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -77,7 +77,7 @@ Xargo makes compiling embedded crates easier. Bindgen automatically generates Ru
 
 ```bash
 cargo install xargo --vers 0.3.8
-cargo install bindgen --vers 0.30.0
+cargo install bindgen --vers 0.31.3
 ```
 
 ## 6. Install Rust Core Source

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,12 @@
 extern crate gcc;
 
+use gcc::Build;
+
 use std::env;
 use std::path::PathBuf;
-
 use std::process::Command;
-
 use std::fs::File;
 use std::io::Write;
-
-use gcc::Config;
 
 fn main() {
 
@@ -48,7 +46,7 @@ fn process_linker_file(outdir: &String) {
 }
 
 fn make_c_deps(outdir: &String) {
-    let mut config = Config::new();
+    let mut config = Build::new();
     let out_path = PathBuf::from(outdir);
 
     config.out_dir(out_path);
@@ -92,7 +90,8 @@ fn generate_ble(outdir: &String) {
     cmd.arg("--use-core");
     cmd.arg("--ctypes-prefix=ctypes");
     cmd.arg("--with-derive-default");
-
+    cmd.arg("--blacklist-type"); 
+    cmd.arg("IRQn_Type");
     cmd.arg("--output");
     cmd.arg(out3.as_ref());
 
@@ -122,7 +121,7 @@ fn generate_ble(outdir: &String) {
     cmd.arg(env::var("TARGET").unwrap());
 
     assert!(cmd.status()
-                .expect("failed to build Blue libs")
+                .expect("failed to build BLE libs")
                 .success());
 }
 

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -3,10 +3,8 @@
 #![no_main]
 #![feature(asm)]
 
-#[macro_use]
 extern crate nrf52dk_sys;
 use nrf52dk_sys as nrf;
-use nrf::check;
 
 #[no_mangle]
 pub unsafe extern "C" fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,4 +60,54 @@ pub fn check(ec: u32) -> Result<(), ()> {
     }
 }
 
+pub const IRQn_Type_Reset_IRQn: IRQn_Type = -15;
+pub const IRQn_Type_NonMaskableInt_IRQn: IRQn_Type = -14;
+pub const IRQn_Type_HardFault_IRQn: IRQn_Type = -13;
+pub const IRQn_Type_MemoryManagement_IRQn: IRQn_Type = -12;
+pub const IRQn_Type_BusFault_IRQn: IRQn_Type = -11;
+pub const IRQn_Type_UsageFault_IRQn: IRQn_Type = -10;
+pub const IRQn_Type_SVCall_IRQn: IRQn_Type = -5;
+pub const IRQn_Type_DebugMonitor_IRQn: IRQn_Type = -4;
+pub const IRQn_Type_PendSV_IRQn: IRQn_Type = -2;
+pub const IRQn_Type_SysTick_IRQn: IRQn_Type = -1;
+pub const IRQn_Type_POWER_CLOCK_IRQn: IRQn_Type = 0;
+pub const IRQn_Type_RADIO_IRQn: IRQn_Type = 1;
+pub const IRQn_Type_UARTE0_UART0_IRQn: IRQn_Type = 2;
+pub const IRQn_Type_SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn: IRQn_Type = 3;
+pub const IRQn_Type_SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn: IRQn_Type = 4;
+pub const IRQn_Type_NFCT_IRQn: IRQn_Type = 5;
+pub const IRQn_Type_GPIOTE_IRQn: IRQn_Type = 6;
+pub const IRQn_Type_SAADC_IRQn: IRQn_Type = 7;
+pub const IRQn_Type_TIMER0_IRQn: IRQn_Type = 8;
+pub const IRQn_Type_TIMER1_IRQn: IRQn_Type = 9;
+pub const IRQn_Type_TIMER2_IRQn: IRQn_Type = 10;
+pub const IRQn_Type_RTC0_IRQn: IRQn_Type = 11;
+pub const IRQn_Type_TEMP_IRQn: IRQn_Type = 12;
+pub const IRQn_Type_RNG_IRQn: IRQn_Type = 13;
+pub const IRQn_Type_ECB_IRQn: IRQn_Type = 14;
+pub const IRQn_Type_CCM_AAR_IRQn: IRQn_Type = 15;
+pub const IRQn_Type_WDT_IRQn: IRQn_Type = 16;
+pub const IRQn_Type_RTC1_IRQn: IRQn_Type = 17;
+pub const IRQn_Type_QDEC_IRQn: IRQn_Type = 18;
+pub const IRQn_Type_COMP_LPCOMP_IRQn: IRQn_Type = 19;
+pub const IRQn_Type_SWI0_EGU0_IRQn: IRQn_Type = 20;
+pub const IRQn_Type_SWI1_EGU1_IRQn: IRQn_Type = 21;
+pub const IRQn_Type_SWI2_EGU2_IRQn: IRQn_Type = 22;
+pub const IRQn_Type_SWI3_EGU3_IRQn: IRQn_Type = 23;
+pub const IRQn_Type_SWI4_EGU4_IRQn: IRQn_Type = 24;
+pub const IRQn_Type_SWI5_EGU5_IRQn: IRQn_Type = 25;
+pub const IRQn_Type_TIMER3_IRQn: IRQn_Type = 26;
+pub const IRQn_Type_TIMER4_IRQn: IRQn_Type = 27;
+pub const IRQn_Type_PWM0_IRQn: IRQn_Type = 28;
+pub const IRQn_Type_PDM_IRQn: IRQn_Type = 29;
+pub const IRQn_Type_MWU_IRQn: IRQn_Type = 32;
+pub const IRQn_Type_PWM1_IRQn: IRQn_Type = 33;
+pub const IRQn_Type_PWM2_IRQn: IRQn_Type = 34;
+pub const IRQn_Type_SPIM2_SPIS2_SPI2_IRQn: IRQn_Type = 35;
+pub const IRQn_Type_RTC2_IRQn: IRQn_Type = 36;
+pub const IRQn_Type_I2S_IRQn: IRQn_Type = 37;
+pub const IRQn_Type_FPU_IRQn: IRQn_Type = 38;
+// Our own type alias to i8
+pub type IRQn_Type = i8;
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
The pattern of generated code changed slightly in bindgen 0.31.3, but one
workaround is to blacklist funky types and provide our own rust implementation.