### PR TITLE
Disable incremental compilation by default.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,4 @@
+
 [target.thumbv7em-none-eabihf]
 rustflags = [
     "-C", "link-arg=-mthumb",
@@ -17,3 +18,4 @@ rustflags = [
 
 [build]
 target = "thumbv7em-none-eabihf"
+incremental = false

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ xargo build --example blinky
        Finished dev [unoptimized + debuginfo] target(s) in 15.66 secs
 ```
 
+**NOTE:** This crate does not work with incremental compilation. In our
+**.cargo/config**, we set `incremental = false`, which corresponds to setting
+`CARGO_INCREMENTAL=0` in your environment.
+
 ## Flashing, Debugging, and Running
 
 ### Flashing the SoftDevice


### PR DESCRIPTION
This change allows users to avoid setting `CARGO_INCREMENTAL=0` in their
environment before building.